### PR TITLE
fix the issue of tied death

### DIFF
--- a/R/cutp.R
+++ b/R/cutp.R
@@ -151,8 +151,8 @@ cutp.coxph <- function(x, ...,
             "U"=abs(unlist(l1)))
         data.table::setnames(res2, old="u1", new=names(d1[i]))
         data.table::setorder(res2, -U)
-        s2 <- findS2(sum(x$nevent))
-        res2[, "Q" := U / (sqrt(s2) * sqrt(sum(x$nevent) - 1))]
+        s2 <- findS2(sum(ten(x$y ~ 0)$e>0))
+        res2[, "Q" := U / (sqrt(s2) * sqrt(sum(ten(x$y ~ 0)$e>0) - 1))]
         res2[, "p" := unlist(lapply(Q, findP))]
         return(res2)
     })


### PR DESCRIPTION
When tied death occurred, the value D mentioned in "Details" should be the number of unique event times, rather than the number of total events. After changing the code, the result is consistent with SAS's (Mandrekar, Mandrekar, & Cha, 2003).